### PR TITLE
Update conf.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 [![Build Status](https://travis-ci.org/multiply-org/multiply-core.svg?branch=master)](https://travis-ci.org/multiply-org/multiply-core)
-[![Documentation Status](https://readthedocs.org/projects/multiply/badge/?version=latest)](http://multiply.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/multiply/badge/?version=latest)](https://multiply.readthedocs.io/)
                 
 # MULTIPLY Core
 
@@ -48,7 +48,7 @@ To import it into your python application, use
 ## Generating the Documentation
 
 We use [Sphinx](http://www.sphinx-doc.org/en/stable/rest.html) to generate the documentation of the MULTIPLY platform 
-on [ReadTheDocs](http://multiply.readthedocs.io/en/latest/). 
+on [ReadTheDocs](https://multiply.readthedocs.io/). 
 If there is a need to build the docs locally, these additional software packages are required:
 
     $ conda install sphinx sphinx_rtd_theme mock

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -47,7 +47,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Multiply'
-copyright = '2017'
+copyright = '2018'
 author = 'MULTIPLY Development Team'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -56,7 +56,7 @@ author = 'MULTIPLY Development Team'
 #
 # The short X.Y version.
 from multiply_core.version import __version__
-version = __version__
+version = ".".join(__version__.split('.')[:3])
 # The full version, including alpha/beta/rc tags.
 release = __version__
 


### PR DESCRIPTION
**1. Idea for doc versioning.
2. Update for 2018.**

Stumbled across this while researching the URL of the multiply core documentation.
Neither the badge URL : https://multiply.readthedocs.io/en/latest/?badge=latest
nor https://multiply.readthedocs.io/en/latest/ in the text are working.
However

- https://multiply.readthedocs.io/
- https://multiply.rtfd.io/

are working.